### PR TITLE
Fix default value for $params argument in Doctrine_Connection_Statement::execute method

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -233,7 +233,7 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      *                                  bound parameters in the SQL statement being executed.
      * @return boolean                  Returns TRUE on success or FALSE on failure.
      */
-    public function execute($params = null)
+    public function execute($params = array())
     {
         try {
             $event = new Doctrine_Event($this, Doctrine_Event::STMT_EXECUTE, $this->getQuery(), $params);


### PR DESCRIPTION
Params default value fix