### PR TITLE
fix doc comment type for Collection::fromArray

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -786,7 +786,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Populate a Doctrine_Collection from an array of data
      *
-     * @param string $array
+     * @param array $array
      * @return void
      */
     public function fromArray($array, $deep = true)


### PR DESCRIPTION
Just a small change to fix the doc comment on the fromArray method. The first argument is clearly an array.